### PR TITLE
memoize + tagging (needs latest memoize-ext)

### DIFF
--- a/rpgicons-l3.sty
+++ b/rpgicons-l3.sty
@@ -61,6 +61,9 @@
 \msg_new:nnn { rpgicons } { precomposed-missing } {
     The ~ icon ~ `#1' ~ has ~ not ~ been ~ precomposed.
 }
+\msg_new:nnn { rpgicons } { loading-pkg } {
+    Loading ~ #1 ~ \msg_line_context: #2.
+}
 \msg_if_exist:nnF { rpgicons } { tagging-unsupported } {
     \msg_new:nnn { rpgicons } { tagging-unsupported } {
         This ~ LaTeX ~ version ~ does ~ not ~ support ~ tagging.
@@ -2789,18 +2792,27 @@
         \AssignTaggingSocketPlug { rpgicons / roll / after } { actualtext }
     }
 
-    \IfPackageLoadedTF { memoize-ext-tag } {
-        \bool_set_true:N \l__rpgicons_mmzx_bool
-        \NewTaggingSocketPlug { memoize/include/extern/before } { rpgicons / icon / actualtext } {
-          \tag_socket_use:no { rpgicons / icon / before } { \the\mmzxtagtoks }
+    \IfPackageLoadedTF { memoize } {
+        \IfPackageLoadedF { memoize-ext } {
+          \msg_info:nnnn { rpgicons } { loading-pkg } { memoize-ext } { ~ for ~
+              memoize ~ tagging ~ support. }
+          \RequirePackage { memoize-ext }
         }
-        \NewTaggingSocketPlug { memoize/include/extern/after } { rpgicons / icon / actualtext } {
+        \bool_set_true:N \l__rpgicons_mmzx_bool
+        \NewTaggingSocketPlug { memoize/include/extern/before } 
+          { rpgicons / icon / actualtext } {
+            \tag_socket_use:no { rpgicons / icon / before } { \the\mmzxtagtoks }
+        }
+        \NewTaggingSocketPlug { memoize/include/extern/after } 
+          { rpgicons / icon / actualtext } {
             \tag_socket_use:n { rpgicons / icon / after }
         }
-        \NewTaggingSocketPlug { memoize/include/extern/before } { rpgicons / roll / actualtext } {
+        \NewTaggingSocketPlug { memoize/include/extern/before } 
+          { rpgicons / roll / actualtext } {
             \tag_socket_use:no { rpgicons / roll / before } { \the\mmzxtagtoks }
         }
-        \NewTaggingSocketPlug { memoize/include/extern/after } { rpgicons / roll / actualtext } {
+        \NewTaggingSocketPlug { memoize/include/extern/after }
+          { rpgicons / roll / actualtext } {
             \tag_socket_use:n { rpgicons / roll / after }
         }
     } {
@@ -2821,6 +2833,52 @@
     \cs_if_exist:NF \tag_resume:n {
         \cs_new:Npn \tag_resume:n #1 { }
     }
+}
+
+\IfPackageLoadedTF { memoize } {
+    \cs_new_protected_nopar:Npn \__rpgicons_keys_to_context: {
+      \mmznext {
+        direct ~ ccmemo ~ input,
+        context/.expanded = \__rpgicons_keys_context: ,
+      }
+    }
+    \cs_new_nopar:Npn \__rpgicons_keys_context: {
+        before ~ sep           
+          = \dim_to_decimal:n { \l_rpgicons_icon_before_sep_dim } ,
+        after ~ sep            
+          = \dim_to_decimal:n { \l_rpgicons_icon_after_sep_dim } ,
+        baseline               
+          = \dim_to_decimal:n { \l_rpgicons_icon_baseline_dim } ,
+        frame                  = \l_rpgicons_icon_frame_tl ,
+        variant                
+          = \int_to_arabic:n { \l_rpgicons_icon_variant_int } ,
+        stroke                 = \l_rpgicons_icon_color_stroke_tl ,
+        fill                   = \l_rpgicons_icon_color_fill_tl ,
+        text                   = \l_rpgicons_icon_color_text_tl ,
+        color                  = \l_rpgicons_icon_color_stroke_tl ,
+           \l_rpgicons_icon_color_fill_tl ,
+           \l_rpgicons_icon_color_text_tl , 
+        background             = \l_rpgicons_icon_color_background_tl ,
+        stroke ~ opacity 
+          = \fp_to_decimal:N \l_rpgicons_icon_opacity_stroke_fp ,
+        fill ~ opacity 
+          = \fp_to_decimal:N \l_rpgicons_icon_opacity_fill_fp ,
+        text ~ opacity   
+          = \fp_to_decimal:N \l_rpgicons_icon_opacity_text_fp ,
+        background ~ opacity   
+          = \fp_to_decimal:N \l_rpgicons_icon_opacity_background_fp ,
+        line ~ width 
+          = \dim_to_decimal:n { \l_rpgicons_icon_linewidth_dim } ,
+        scale = \fp_to_decimal:N \l_rpgicons_icon_transform_scale_fp ,
+        scale ~ inner  
+          = \fp_to_decimal:N \l_rpgicons_icon_transform_scale_inner_fp ,
+        rotate  = \fp_to_decimal:N \l_rpgicons_icon_transform_rotate_fp ,
+        % alias     ,
+        precompose ~ output    = \l_rpgicons_precompose_output_str ,
+        actualtext             = \l_rpgicons_icon_actualtext_str ,
+    }
+} {
+  \cs_if_free:cT { ifmemoize } { \newif\ifmemoize\memoizefalse }
 }
 
 % === precompose icons
@@ -3065,30 +3123,33 @@
             \str_put_left:Nn \l_rpgicons_icon_actualtext_str { #3 ~ }
         }
         \tag_socket_use:nV { rpgicons / icon / before } \l_rpgicons_icon_actualtext_str
-        \bool_if:NT \l__rpgicons_mmzx_bool {
-            \xtoksapp\mmzCCMemo {
-                \exp_not:N \mmzxtagtoks
-                =
-                \c_left_brace_str
-                \l_rpgicons_icon_actualtext_str
-                \the\mmzxtagtoks
-                \c_right_brace_str
-                \exp_not:N \AssignSocketPlug
-                \c_left_brace_str
-                tagsupport/memoize/include/extern/before
-                \c_right_brace_str
-                \c_left_brace_str
-                rpgicons / icon / actualtext
-                \c_right_brace_str
-                \exp_not:N \AssignSocketPlug
-                \c_left_brace_str
-                tagsupport/memoize/include/extern/after
-                \c_right_brace_str
-                \c_left_brace_str
-                rpgicons / icon / actualtext
-                \c_right_brace_str
+        \ifmemoize
+            \__rpgicons_keys_to_context:
+            \bool_if:NT \l__rpgicons_mmzx_bool {
+                \xtoksapp\mmzCCMemo {
+                    \exp_not:N \mmzxtagtoks
+                    =
+                    \c_left_brace_str
+                    \l_rpgicons_icon_actualtext_str
+                    \the\mmzxtagtoks
+                    \c_right_brace_str
+                    \exp_not:N \AssignSocketPlug
+                    \c_left_brace_str
+                    tagsupport/memoize/include/extern/before
+                    \c_right_brace_str
+                    \c_left_brace_str
+                    rpgicons / icon / actualtext
+                    \c_right_brace_str
+                    \exp_not:N \AssignSocketPlug
+                    \c_left_brace_str
+                    tagsupport/memoize/include/extern/after
+                    \c_right_brace_str
+                    \c_left_brace_str
+                    rpgicons / icon / actualtext
+                    \c_right_brace_str
+                }
             }
-        }
+        \fi
         \bool_if:NTF \l__rpgicons_icon_precompose_bool {
             \__rpgicons_load_icon:ee {
                 \str_if_empty:NTF \l_rpgicons_icon_precompose_ref_str {
@@ -3403,30 +3464,33 @@
     \mode_leave_vertical:
     \__rpgicons_roll_prepare_actualtext:Nn \l__rpgicons_roll_actualtext_tl {#1}
     \tag_socket_use:nV { rpgicons / roll / before } \l__rpgicons_roll_actualtext_tl
-    \bool_if:NT \l__rpgicons_mmzx_bool {
-        \xtoksapp\mmzCCMemo {
-            \exp_not:N \mmzxtagtoks
-            =
-            \c_left_brace_str
-            \l__rpgicons_roll_actualtext_tl
-            \the\mmzxtagtoks
-            \c_right_brace_str
-            \exp_not:N \AssignSocketPlug
-            \c_left_brace_str
-            tagsupport/memoize/include/extern/before
-            \c_right_brace_str
-            \c_left_brace_str
-            rpgicons / roll / actualtext
-            \c_right_brace_str
-            \exp_not:N \AssignSocketPlug
-            \c_left_brace_str
-            tagsupport/memoize/include/extern/after
-            \c_right_brace_str
-            \c_left_brace_str
-            rpgicons / roll / actualtext
-            \c_right_brace_str
+    \ifmemoize
+        \__rpgicons_keys_to_context:
+        \bool_if:NT \l__rpgicons_mmzx_bool {
+            \xtoksapp\mmzCCMemo {
+                \exp_not:N \mmzxtagtoks
+                =
+                \c_left_brace_str
+                \l__rpgicons_roll_actualtext_tl
+                \the\mmzxtagtoks
+                \c_right_brace_str
+                \exp_not:N \AssignSocketPlug
+                \c_left_brace_str
+                tagsupport/memoize/include/extern/before
+                \c_right_brace_str
+                \c_left_brace_str
+                rpgicons / roll / actualtext
+                \c_right_brace_str
+                \exp_not:N \AssignSocketPlug
+                \c_left_brace_str
+                tagsupport/memoize/include/extern/after
+                \c_right_brace_str
+                \c_left_brace_str
+                rpgicons / roll / actualtext
+                \c_right_brace_str
+            }
         }
-    }
+    \fi
     \tag_suspend:n { \RPGIconsRoll }
     \__rpgicons_roll_syntax_parse:e {#1}
     \tag_resume:n { \RPGIconsRoll }

--- a/rpgicons-l3.sty
+++ b/rpgicons-l3.sty
@@ -2802,20 +2802,20 @@
     \cs_if_free:cT { ifmemoize } { \newif\ifmemoize\memoizefalse }
 }
 
+\cs_generate_variant:Nn \mmzx_tag_socket_plug_record:nnn {nnv}
 \cs_new_protected:Npn \__rpgicons_maybe_memoize:n #1
 {
     \bool_if:NT \l__rpgicons_mmzx_bool {
         \__rpgicons_keys_to_context:
         \bool_if:NT \l__rpgicons_mmzx_tag_bool {
-            \exp_args:NNv \mmzxtagtoks =  { l_rpgicons_#1_actualtext_str }
-            \mmzx_tag_socket_plug_record:nn { rpgicons / #1 / before }
-                { rpgicons / #1 /after }
+            \mmzx_tag_socket_plug_record:nnv { rpgicons / #1 / before }
+                { rpgicons / #1 /after } { l_rpgicons_#1_actualtext_str }
         }
     }
 }
 
 \cs_if_exist:NTF \NewTaggingSocket {
-    \cs_generate_variant:Nn \tag_socket_use:nn { nV, no }
+    \cs_generate_variant:Nn \tag_socket_use:nn { nV, nv }
 
     \NewTaggingSocket { rpgicons / icon / before } { 1 }
     \NewTaggingSocketPlug { rpgicons / icon / before } { actualtext } {
@@ -2861,21 +2861,20 @@
 
     \IfPackageLoadedT { memoize-ext-tag } {
         \bool_set_true:N \l__rpgicons_mmzx_tag_bool
-        \NewTaggingSocketPlug { memoize/include/extern/before } 
-          { rpgicons / icon / actualtext } {
-            \tag_socket_use:no { rpgicons / icon / before } { \the\mmzxtagtoks }
-        }
-        \NewTaggingSocketPlug { memoize/include/extern/after } 
-          { rpgicons / icon / actualtext } {
-            \tag_socket_use:n { rpgicons / icon / after }
-        }
-        \NewTaggingSocketPlug { memoize/include/extern/before } 
-          { rpgicons / roll / actualtext } {
-            \tag_socket_use:no { rpgicons / roll / before } { \the\mmzxtagtoks }
-        }
-        \NewTaggingSocketPlug { memoize/include/extern/after }
-          { rpgicons / roll / actualtext } {
-            \tag_socket_use:n { rpgicons / roll / after }
+        \cs_generate_variant:Nn \__rpgicons_precompose_register:nnnn { V }
+        \cs_generate_variant:Nn \mmzx_tag_get_recorded:N {c}
+        \clist_map_inline:nn {  icon, roll }
+        {
+            \NewTaggingSocketPlug { memoize/include/extern/before } 
+            { rpgicons / #1 / actualtext } {
+                \mmzx_tag_get_recorded:c { l_rpgicons_#1_actualtext_str }
+                \tag_socket_use:nv { rpgicons / #1 / before } 
+                { l_rpgicons_#1_actualtext_str }
+            }
+            \NewTaggingSocketPlug { memoize/include/extern/after } 
+            { rpgicons / #1 / actualtext } {
+                \tag_socket_use:n { rpgicons / #1 / after }
+            }
         }
     } 
   } {
@@ -2944,7 +2943,6 @@
         | #1 | \prop_to_keyval:c { g__rpgicons_precompose_ #1 _prop } |
     }
 }
-\cs_generate_variant:Nn \__rpgicons_precompose_register:nnnn { V }
 
 \sys_ensure_backend:
 \NewDocumentCommand \RPGIconsPrecomposeIcon { s O { } o m } {

--- a/rpgicons-l3.sty
+++ b/rpgicons-l3.sty
@@ -14,6 +14,7 @@
     {RPG Icons Package (l3 Variant)}
 
 \bool_new:N \l__rpgicons_unicode_mode_bool
+\bool_new:N \l__rpgicons_mmzx_bool
 \sys_if_engine_luatex:T {
     \bool_set_true:N \l__rpgicons_unicode_mode_bool
 }
@@ -2744,7 +2745,7 @@
 }
 
 \cs_if_exist:NTF \NewTaggingSocket {
-    \cs_generate_variant:Nn \tag_socket_use:nn { nV }
+    \cs_generate_variant:Nn \tag_socket_use:nn { nV, no }
 
     \NewTaggingSocket { rpgicons / icon / before } { 1 }
     \NewTaggingSocketPlug { rpgicons / icon / before } { actualtext } {
@@ -2786,6 +2787,24 @@
             \tag_mc_begin_pop:n { }
         }
         \AssignTaggingSocketPlug { rpgicons / roll / after } { actualtext }
+    }
+
+    \IfPackageLoadedTF { memoize-ext-tag } {
+        \bool_set_true:N \l__rpgicons_mmzx_bool
+        \NewTaggingSocketPlug { memoize/include/extern/before } { rpgicons / icon / actualtext } {
+          \tag_socket_use:no { rpgicons / icon / before } { \the\mmzxtagtoks }
+        }
+        \NewTaggingSocketPlug { memoize/include/extern/after } { rpgicons / icon / actualtext } {
+            \tag_socket_use:n { rpgicons / icon / after }
+        }
+        \NewTaggingSocketPlug { memoize/include/extern/before } { rpgicons / roll / actualtext } {
+            \tag_socket_use:no { rpgicons / roll / before } { \the\mmzxtagtoks }
+        }
+        \NewTaggingSocketPlug { memoize/include/extern/after } { rpgicons / roll / actualtext } {
+            \tag_socket_use:n { rpgicons / roll / after }
+        }
+    } {
+      \bool_set_false:N \l__rpgicons_mmzx_bool
     }
 } {
     \msg_warning:nn { rpgicons } { tagging-unsupported }
@@ -3046,6 +3065,30 @@
             \str_put_left:Nn \l_rpgicons_icon_actualtext_str { #3 ~ }
         }
         \tag_socket_use:nV { rpgicons / icon / before } \l_rpgicons_icon_actualtext_str
+        \bool_if:NT \l__rpgicons_mmzx_bool {
+            \xtoksapp\mmzCCMemo {
+                \exp_not:N \mmzxtagtoks
+                =
+                \c_left_brace_str
+                \l_rpgicons_icon_actualtext_str
+                \the\mmzxtagtoks
+                \c_right_brace_str
+                \exp_not:N \AssignSocketPlug
+                \c_left_brace_str
+                tagsupport/memoize/include/extern/before
+                \c_right_brace_str
+                \c_left_brace_str
+                rpgicons / icon / actualtext
+                \c_right_brace_str
+                \exp_not:N \AssignSocketPlug
+                \c_left_brace_str
+                tagsupport/memoize/include/extern/after
+                \c_right_brace_str
+                \c_left_brace_str
+                rpgicons / icon / actualtext
+                \c_right_brace_str
+            }
+        }
         \bool_if:NTF \l__rpgicons_icon_precompose_bool {
             \__rpgicons_load_icon:ee {
                 \str_if_empty:NTF \l_rpgicons_icon_precompose_ref_str {
@@ -3360,6 +3403,30 @@
     \mode_leave_vertical:
     \__rpgicons_roll_prepare_actualtext:Nn \l__rpgicons_roll_actualtext_tl {#1}
     \tag_socket_use:nV { rpgicons / roll / before } \l__rpgicons_roll_actualtext_tl
+    \bool_if:NT \l__rpgicons_mmzx_bool {
+        \xtoksapp\mmzCCMemo {
+            \exp_not:N \mmzxtagtoks
+            =
+            \c_left_brace_str
+            \l__rpgicons_roll_actualtext_tl
+            \the\mmzxtagtoks
+            \c_right_brace_str
+            \exp_not:N \AssignSocketPlug
+            \c_left_brace_str
+            tagsupport/memoize/include/extern/before
+            \c_right_brace_str
+            \c_left_brace_str
+            rpgicons / roll / actualtext
+            \c_right_brace_str
+            \exp_not:N \AssignSocketPlug
+            \c_left_brace_str
+            tagsupport/memoize/include/extern/after
+            \c_right_brace_str
+            \c_left_brace_str
+            rpgicons / roll / actualtext
+            \c_right_brace_str
+        }
+    }
     \tag_suspend:n { \RPGIconsRoll }
     \__rpgicons_roll_syntax_parse:e {#1}
     \tag_resume:n { \RPGIconsRoll }

--- a/rpgicons-l3.sty
+++ b/rpgicons-l3.sty
@@ -15,6 +15,8 @@
 
 \bool_new:N \l__rpgicons_unicode_mode_bool
 \bool_new:N \l__rpgicons_mmzx_bool
+\bool_new:N \l__rpgicons_mmzx_tag_bool
+\bool_set_false:N \l__rpgicons_mmzx_tag_bool
 \sys_if_engine_luatex:T {
     \bool_set_true:N \l__rpgicons_unicode_mode_bool
 }
@@ -2747,6 +2749,59 @@
     }
 }
 
+\IfPackageLoadedTF { memoize } {
+    \IfPackageLoadedF { memoize-ext } {
+        \msg_info:nnnn { rpgicons } { loading-pkg } { memoize-ext } { ~ for ~
+            memoize ~ support. }
+        \RequirePackage { memoize-ext }
+    }
+    \bool_set_true:N \l__rpgicons_mmzx_bool
+    \cs_new_protected_nopar:Npn \__rpgicons_keys_to_context: {
+      \mmznext {
+        direct ~ ccmemo ~ input,
+        context/.expanded = \__rpgicons_keys_context: ,
+      }
+    }
+    \cs_new_nopar:Npn \__rpgicons_keys_context: {
+        before ~ sep           
+          = \dim_to_decimal:n { \l_rpgicons_icon_before_sep_dim } ,
+        after ~ sep            
+          = \dim_to_decimal:n { \l_rpgicons_icon_after_sep_dim } ,
+        baseline               
+          = \dim_to_decimal:n { \l_rpgicons_icon_baseline_dim } ,
+        frame                  = \l_rpgicons_icon_frame_tl ,
+        variant                
+          = \int_to_arabic:n { \l_rpgicons_icon_variant_int } ,
+        stroke                 = \l_rpgicons_icon_color_stroke_tl ,
+        fill                   = \l_rpgicons_icon_color_fill_tl ,
+        text                   = \l_rpgicons_icon_color_text_tl ,
+        color                  = \l_rpgicons_icon_color_stroke_tl ,
+           \l_rpgicons_icon_color_fill_tl ,
+           \l_rpgicons_icon_color_text_tl , 
+        background             = \l_rpgicons_icon_color_background_tl ,
+        stroke ~ opacity 
+          = \fp_to_decimal:N \l_rpgicons_icon_opacity_stroke_fp ,
+        fill ~ opacity 
+          = \fp_to_decimal:N \l_rpgicons_icon_opacity_fill_fp ,
+        text ~ opacity   
+          = \fp_to_decimal:N \l_rpgicons_icon_opacity_text_fp ,
+        background ~ opacity   
+          = \fp_to_decimal:N \l_rpgicons_icon_opacity_background_fp ,
+        line ~ width 
+          = \dim_to_decimal:n { \l_rpgicons_icon_linewidth_dim } ,
+        scale = \fp_to_decimal:N \l_rpgicons_icon_transform_scale_fp ,
+        scale ~ inner  
+          = \fp_to_decimal:N \l_rpgicons_icon_transform_scale_inner_fp ,
+        rotate  = \fp_to_decimal:N \l_rpgicons_icon_transform_rotate_fp ,
+        % alias     ,
+        precompose ~ output    = \l_rpgicons_precompose_output_str ,
+        actualtext             = \l_rpgicons_icon_actualtext_str ,
+    }
+} {
+    \bool_set_false:N \l__rpgicons_mmzx_bool
+    \cs_if_free:cT { ifmemoize } { \newif\ifmemoize\memoizefalse }
+}
+
 \cs_if_exist:NTF \NewTaggingSocket {
     \cs_generate_variant:Nn \tag_socket_use:nn { nV, no }
 
@@ -2792,13 +2847,8 @@
         \AssignTaggingSocketPlug { rpgicons / roll / after } { actualtext }
     }
 
-    \IfPackageLoadedTF { memoize } {
-        \IfPackageLoadedF { memoize-ext } {
-          \msg_info:nnnn { rpgicons } { loading-pkg } { memoize-ext } { ~ for ~
-              memoize ~ tagging ~ support. }
-          \RequirePackage { memoize-ext }
-        }
-        \bool_set_true:N \l__rpgicons_mmzx_bool
+    \IfPackageLoadedT { memoize-ext-tag } {
+        \bool_set_true:N \l__rpgicons_mmzx_tag_bool
         \NewTaggingSocketPlug { memoize/include/extern/before } 
           { rpgicons / icon / actualtext } {
             \tag_socket_use:no { rpgicons / icon / before } { \the\mmzxtagtoks }
@@ -2815,10 +2865,8 @@
           { rpgicons / roll / actualtext } {
             \tag_socket_use:n { rpgicons / roll / after }
         }
-    } {
-      \bool_set_false:N \l__rpgicons_mmzx_bool
-    }
-} {
+    } 
+  } {
     \msg_warning:nn { rpgicons } { tagging-unsupported }
     \cs_if_exist:NF \tag_socket_use:n {
         \cs_new:Npn \tag_socket_use:n #1 { }
@@ -2835,51 +2883,6 @@
     }
 }
 
-\IfPackageLoadedTF { memoize } {
-    \cs_new_protected_nopar:Npn \__rpgicons_keys_to_context: {
-      \mmznext {
-        direct ~ ccmemo ~ input,
-        context/.expanded = \__rpgicons_keys_context: ,
-      }
-    }
-    \cs_new_nopar:Npn \__rpgicons_keys_context: {
-        before ~ sep           
-          = \dim_to_decimal:n { \l_rpgicons_icon_before_sep_dim } ,
-        after ~ sep            
-          = \dim_to_decimal:n { \l_rpgicons_icon_after_sep_dim } ,
-        baseline               
-          = \dim_to_decimal:n { \l_rpgicons_icon_baseline_dim } ,
-        frame                  = \l_rpgicons_icon_frame_tl ,
-        variant                
-          = \int_to_arabic:n { \l_rpgicons_icon_variant_int } ,
-        stroke                 = \l_rpgicons_icon_color_stroke_tl ,
-        fill                   = \l_rpgicons_icon_color_fill_tl ,
-        text                   = \l_rpgicons_icon_color_text_tl ,
-        color                  = \l_rpgicons_icon_color_stroke_tl ,
-           \l_rpgicons_icon_color_fill_tl ,
-           \l_rpgicons_icon_color_text_tl , 
-        background             = \l_rpgicons_icon_color_background_tl ,
-        stroke ~ opacity 
-          = \fp_to_decimal:N \l_rpgicons_icon_opacity_stroke_fp ,
-        fill ~ opacity 
-          = \fp_to_decimal:N \l_rpgicons_icon_opacity_fill_fp ,
-        text ~ opacity   
-          = \fp_to_decimal:N \l_rpgicons_icon_opacity_text_fp ,
-        background ~ opacity   
-          = \fp_to_decimal:N \l_rpgicons_icon_opacity_background_fp ,
-        line ~ width 
-          = \dim_to_decimal:n { \l_rpgicons_icon_linewidth_dim } ,
-        scale = \fp_to_decimal:N \l_rpgicons_icon_transform_scale_fp ,
-        scale ~ inner  
-          = \fp_to_decimal:N \l_rpgicons_icon_transform_scale_inner_fp ,
-        rotate  = \fp_to_decimal:N \l_rpgicons_icon_transform_rotate_fp ,
-        % alias     ,
-        precompose ~ output    = \l_rpgicons_precompose_output_str ,
-        actualtext             = \l_rpgicons_icon_actualtext_str ,
-    }
-} {
-  \cs_if_free:cT { ifmemoize } { \newif\ifmemoize\memoizefalse }
-}
 
 % === precompose icons
 \iow_new:N \l__rpgicons_precompose_document_iow
@@ -3123,9 +3126,9 @@
             \str_put_left:Nn \l_rpgicons_icon_actualtext_str { #3 ~ }
         }
         \tag_socket_use:nV { rpgicons / icon / before } \l_rpgicons_icon_actualtext_str
-        \ifmemoize
+        \bool_if:NT \l__rpgicons_mmzx_bool {
             \__rpgicons_keys_to_context:
-            \bool_if:NT \l__rpgicons_mmzx_bool {
+            \bool_if:NT \l__rpgicons_mmzx_tag_bool {
                 \xtoksapp\mmzCCMemo {
                     \exp_not:N \mmzxtagtoks
                     =
@@ -3149,7 +3152,7 @@
                     \c_right_brace_str
                 }
             }
-        \fi
+        }
         \bool_if:NTF \l__rpgicons_icon_precompose_bool {
             \__rpgicons_load_icon:ee {
                 \str_if_empty:NTF \l_rpgicons_icon_precompose_ref_str {
@@ -3464,9 +3467,9 @@
     \mode_leave_vertical:
     \__rpgicons_roll_prepare_actualtext:Nn \l__rpgicons_roll_actualtext_tl {#1}
     \tag_socket_use:nV { rpgicons / roll / before } \l__rpgicons_roll_actualtext_tl
-    \ifmemoize
+    \bool_if:NT \l__rpgicons_mmzx_bool {
         \__rpgicons_keys_to_context:
-        \bool_if:NT \l__rpgicons_mmzx_bool {
+        \bool_if:NT \l__rpgicons_mmzx_tag_bool {
             \xtoksapp\mmzCCMemo {
                 \exp_not:N \mmzxtagtoks
                 =
@@ -3490,7 +3493,7 @@
                 \c_right_brace_str
             }
         }
-    \fi
+    }
     \tag_suspend:n { \RPGIconsRoll }
     \__rpgicons_roll_syntax_parse:e {#1}
     \tag_resume:n { \RPGIconsRoll }

--- a/rpgicons-l3.sty
+++ b/rpgicons-l3.sty
@@ -2802,6 +2802,18 @@
     \cs_if_free:cT { ifmemoize } { \newif\ifmemoize\memoizefalse }
 }
 
+\cs_new_protected:Npn \__rpgicons_maybe_memoize:n #1
+{
+    \bool_if:NT \l__rpgicons_mmzx_bool {
+        \__rpgicons_keys_to_context:
+        \bool_if:NT \l__rpgicons_mmzx_tag_bool {
+            \exp_args:NNv \mmzxtagtoks =  { l_rpgicons_#1_actualtext_str }
+            \mmzx_tag_socket_plug_record:nn { rpgicons / #1 / before }
+                { rpgicons / #1 /after }
+        }
+    }
+}
+
 \cs_if_exist:NTF \NewTaggingSocket {
     \cs_generate_variant:Nn \tag_socket_use:nn { nV, no }
 
@@ -3126,33 +3138,7 @@
             \str_put_left:Nn \l_rpgicons_icon_actualtext_str { #3 ~ }
         }
         \tag_socket_use:nV { rpgicons / icon / before } \l_rpgicons_icon_actualtext_str
-        \bool_if:NT \l__rpgicons_mmzx_bool {
-            \__rpgicons_keys_to_context:
-            \bool_if:NT \l__rpgicons_mmzx_tag_bool {
-                \xtoksapp\mmzCCMemo {
-                    \exp_not:N \mmzxtagtoks
-                    =
-                    \c_left_brace_str
-                    \l_rpgicons_icon_actualtext_str
-                    \the\mmzxtagtoks
-                    \c_right_brace_str
-                    \exp_not:N \AssignSocketPlug
-                    \c_left_brace_str
-                    tagsupport/memoize/include/extern/before
-                    \c_right_brace_str
-                    \c_left_brace_str
-                    rpgicons / icon / actualtext
-                    \c_right_brace_str
-                    \exp_not:N \AssignSocketPlug
-                    \c_left_brace_str
-                    tagsupport/memoize/include/extern/after
-                    \c_right_brace_str
-                    \c_left_brace_str
-                    rpgicons / icon / actualtext
-                    \c_right_brace_str
-                }
-            }
-        }
+        \__rpgicons_maybe_memoize:n { icon }
         \bool_if:NTF \l__rpgicons_icon_precompose_bool {
             \__rpgicons_load_icon:ee {
                 \str_if_empty:NTF \l_rpgicons_icon_precompose_ref_str {
@@ -3467,33 +3453,8 @@
     \mode_leave_vertical:
     \__rpgicons_roll_prepare_actualtext:Nn \l__rpgicons_roll_actualtext_tl {#1}
     \tag_socket_use:nV { rpgicons / roll / before } \l__rpgicons_roll_actualtext_tl
-    \bool_if:NT \l__rpgicons_mmzx_bool {
-        \__rpgicons_keys_to_context:
-        \bool_if:NT \l__rpgicons_mmzx_tag_bool {
-            \xtoksapp\mmzCCMemo {
-                \exp_not:N \mmzxtagtoks
-                =
-                \c_left_brace_str
-                \l__rpgicons_roll_actualtext_tl
-                \the\mmzxtagtoks
-                \c_right_brace_str
-                \exp_not:N \AssignSocketPlug
-                \c_left_brace_str
-                tagsupport/memoize/include/extern/before
-                \c_right_brace_str
-                \c_left_brace_str
-                rpgicons / roll / actualtext
-                \c_right_brace_str
-                \exp_not:N \AssignSocketPlug
-                \c_left_brace_str
-                tagsupport/memoize/include/extern/after
-                \c_right_brace_str
-                \c_left_brace_str
-                rpgicons / roll / actualtext
-                \c_right_brace_str
-            }
-        }
-    }
+    \__rpgicons_maybe_memoize:n { roll}
+    
     \tag_suspend:n { \RPGIconsRoll }
     \__rpgicons_roll_syntax_parse:e {#1}
     \tag_resume:n { \RPGIconsRoll }

--- a/rpgicons-pgf.sty
+++ b/rpgicons-pgf.sty
@@ -1489,7 +1489,7 @@
     rpg icons/every spell/.meaning to context,
     rpg icons/every #1,
     rpg icons/every #1/.meaning to context,
-    actualtext={#1},% cfr: shoulw this be #1? the edit had #2, but ...
+    actualtext={#1},
     baseline=\rpgicons@baseline, #2] {
       \ifmemoizing
         \xtoksapp\mmzContextExtra{%

--- a/rpgicons-pgf.sty
+++ b/rpgicons-pgf.sty
@@ -18,6 +18,26 @@
 \DeclareOption{pics}{\rpgicons@picstrue}
 \ProcessOptions\relax
 
+\newif\ifrpgicons@mmzx@tag@bool
+\rpgicons@mmzx@tag@boolfalse
+\ExplSyntaxOn
+% or load memoizable?
+\IfPackageLoadedTF{memoize}{
+  \tag_if_active:T { % not adequate?
+    \RequirePackage{memoize-ext}
+    \rpgicons@mmzx@tag@booltrue
+  }
+} {
+  \IfPackageLoadedF{nomemoize}{
+    \newif\ifmemoize\memoizefalse
+    \newif\ifmemoizing\memoizingfalse
+    \pgfqkeys{/handlers}{
+      .meaning ~ to ~ context/.code = {},
+    }
+  }
+}
+\ExplSyntaxOff
+
 \RequirePackage{tikz}
 \newlength{\rpgicons@beforesep}
 \newlength{\rpgicons@aftersep}
@@ -97,7 +117,7 @@
   %
   rpg icons/create every style/.code={
     \tikzset{
-      rpg icons/every #1/.style={}
+      rpg icons/every #1/.style={},
     }
   },
   rpg icons/create every style/.list/.expanded={%
@@ -593,10 +613,16 @@
   \ifx\rpgicons@dieiconnrmlrg\rpgicons@dieiconlrg\else\rpgicons@ifEmptyF{#4}{#4\,}\fi%
   \hspace{\rpgicons@beforesep}%
   \tikz[rpg icons, rpg icons/every die, rpg icons/every #2, actualtext=\rpgicons@dieactualtext,
+    rpg icons/.meaning to context, 
+    rpg icons/every die/.meaning to context, 
+    rpg icons/every #2/.meaning to context,
     baseline=\rpgicons@baseline, fgnrm/.style={scale=.333}, fglrg/.style={scale=.675}, #3] {
-    \node[\rpgicons@shape@variant{#2}, draw, \rpgicons@dieiconfg, font={\footnotesize}] at (0cm,0cm)
-      {\ifx\rpgicons@dieiconnrmlrg\rpgicons@dieiconlrg\textbf{#4}\fi};
-    \path[draw=none, \rpgicons@dieiconfg] ([yshift=-1pt].425cm,.425cm) rectangle ([yshift=1pt]-.425cm,-.425cm);
+    \ifmemoizing\xtoksapp\mmzContextExtra{baseline=\the\rpgicons@baseline,
+        actualtext=\UseName{l__tikz_tagging_actualtext_tl},
+    }\fi
+    \node[\rpgicons@shape@variant{#2}, draw, \rpgicons@diceiconfg, font={\footnotesize}] at (0cm,0cm)
+      {\ifx\rpgicons@diceiconnrmlrg\rpgicons@diceiconlrg\textbf{#4}\fi};
+    \path[draw=none, \rpgicons@diceiconfg] ([yshift=-1pt].425cm,.425cm) rectangle ([yshift=1pt]-.425cm,-.425cm);
   }%
   \hspace{\rpgicons@aftersep}%
 }
@@ -1132,8 +1158,26 @@
     \def\rpgicons@abilityiconfg{fgneg}\else%
     \def\rpgicons@abilityiconfg{fgpos}\fi%
   \hspace{\rpgicons@beforesep}%
-  \tikz[rpg icons, rpg icons/every ability, rpg icons/every #2, actualtext={#2},
-    baseline=\rpgicons@baseline, fgpos/.style={draw}, fgneg/.style={draw=rpgicons@bg, line width=.6pt}, #3] {
+  \tikz[rpg icons, 
+    rpg icons/.meaning to context,
+    rpg icons/every ability, 
+    rpg icons/every ability/.meaning to context,
+    rpg icons/every #2,
+    rpg icons/every #2/.meaning to context,
+    baseline=\rpgicons@baseline, 
+    actualtext={#2},
+    fgpos/.style={draw}, fgneg/.style={draw=rpgicons@bg, line width=.6pt}, #3,
+  ] {
+    \ifmemoizing
+      \begingroup
+        \color{rpgicons@bg}%
+        \xtoksapp\mmzContextExtra{%
+          baseline=\the\rpgicons@baseline,
+          draw=\current@color,
+          actualtext=\UseName{l__tikz_tagging_actualtext_tl},
+        }
+      \endgroup
+    \fi
     \ifx\rpgicons@abilityiconposneg\rpgicons@abilityiconneg%
       \path[scale=.333, fill] (0cm,0cm) circle[radius=.45cm];
       \node[\rpgicons@shape@variant{#2}, \rpgicons@abilityiconfg, scale=.225] at (0cm,0cm) {};
@@ -1157,8 +1201,23 @@
     \def\rpgicons@savingactualtext{#2 saving}%
   \fi%
   \hspace{\rpgicons@beforesep}%
-  \tikz[rpg icons, rpg icons/every saving, \rpgicons@savingstyle, actualtext=\rpgicons@savingactualtext,
+  \tikz[rpg icons, 
+    rpg icons/.meaning to context,
+    rpg icons/every saving, 
+    rpg icons/every saving/.meaning to context,
+    \rpgicons@savingstyle,
+    actualtext=\rpgicons@savingactualtext,
     baseline=\rpgicons@baseline, #3] {
+    \ifmemoizing
+      \begingroup
+      \color{rpgicons@bg}
+      \xtoksapp\mmzContextExtra{%
+        baseline=\the\rpgicons@baseline,
+        draw=\current@color,
+        actualtext=\UseName{l__tikz_tagging_actualtext_tl},
+      }
+      \endgroup
+    \fi
     \path[draw, scale=.333] (-.45cm,.45cm) -- (.45cm,.45cm) -- (.45cm,-.05cm)
       arc[start angle=360, end angle=180, radius=.45cm] -- cycle;
     \ifx\rpgicons@abilityiconnrmemp\rpgicons@abilityiconemp\else%
@@ -1420,8 +1479,20 @@
 
 \NewDocumentCommand{\rpgiconsspell}{ m O{} }{%
   \hspace{\rpgicons@beforesep}%
-  \tikz[rpg icons, rpg icons/every spell, rpg icons/every #1, actualtext={#1},
+  \tikz[rpg icons, 
+    rpg icons/.meaning to context,
+    rpg icons/every spell, 
+    rpg icons/every spell/.meaning to context,
+    rpg icons/every #1,
+    rpg icons/every #1/.meaning to context,
+    actualtext={#1},% cfr: shoulw this be #1? the edit had #2, but ...
     baseline=\rpgicons@baseline, #2] {
+      \ifmemoizing
+        \xtoksapp\mmzContextExtra{%
+          baseline=\the\rpgicons@baseline,
+          actualtext=\UseName{l__tikz_tagging_actualtext_tl},
+        }
+      \fi
     \node[\rpgicons@shape@variant{#1}, draw, scale=.333] at (0cm,0cm) {};
     \path[draw=none, scale=.333] ([yshift=-1pt].425cm,.425cm) rectangle ([yshift=1pt]-.425cm,-.425cm);
   }%
@@ -1615,9 +1686,25 @@
     \def\rpgicons@spellschooliconbg{bgneg}\else%
     \def\rpgicons@spellschooliconbg{bgpos}\fi%
   \hspace{\rpgicons@beforesep}%
-  \tikz[rpg icons, rpg icons/every spellschool, rpg icons/every #2, actualtext={#2},
+  \tikz[rpg icons, 
+    rpg icons/.meaning to context,
+    rpg icons/every spellschool, 
+    rpg icons/.meaning to context, 
+    rpg icons/every #2,
+    rpg icons/every #2/.meaning to context,
+    actualtext={#2},
     baseline=\rpgicons@baseline, fgpos/.style={draw=rpgicons@bg, line width=.6pt}, fgneg/.style={draw},
     bgpos/.style={fill}, bgneg/.style={draw}, #3] {
+    \ifmemoizing
+      \begingroup
+      \color{rpgicons@bg}
+      \xtoksapp\mmzContextExtra{%
+        baseline=\the\rpgicons@baseline,
+        draw=\current@color,
+        actualtext=\UseName{l__tikz_tagging_actualtext_tl},
+      }
+      \endgroup
+    \fi
     \path[scale=.333, \rpgicons@spellschooliconbg] (-.475cm,.35cm)
       -- (-.35cm,.475cm) -- (.35cm,.475cm) -- (.475cm,.35cm) -- (.425cm,-.375cm) -- (0cm,-.475cm) -- (-.425cm,-.375cm) -- cycle;
     \node[\rpgicons@shape@variant{#2}, \rpgicons@spellschooliconfg, scale=.225] at (0cm,0cm) {};
@@ -1984,8 +2071,18 @@
 
 \NewDocumentCommand{\rpgiconsdamage}{ m O{} }{%
   \hspace{\rpgicons@beforesep}%
-  \tikz[rpg icons, rpg icons/every damage, rpg icons/every #1, actualtext={#1},
+  \tikz[rpg icons, 
+    rpg icons/.meaning to context,
+    rpg icons/every damage, 
+    rpg icons/every damage/.meaning to context, 
+    rpg icons/every #1,
+    rpg icons/every #1/.meaning to context,
+    actualtext={#1},
+    /mmz/context=\rpgicons@baseline,
     baseline=\rpgicons@baseline, #2] {
+      \ifmemoizing\xtoksapp\mmzContextExtra{baseline=\the\rpgicons@baseline,
+        actualtext=\UseName{l__tikz_tagging_actualtext_tl},
+      }\fi
     \path[draw, scale=.333] (0cm,0cm) circle[radius=.5cm];
     \node[\rpgicons@shape@variant{#1}, draw, scale=.225] at (0cm,0cm) {};
     \path[draw=none, scale=.333] ([yshift=-1pt].425cm,.425cm) rectangle ([yshift=1pt]-.425cm,-.425cm);
@@ -2170,8 +2267,17 @@
 
 \NewDocumentCommand{\rpgiconsattack}{ m O{} }{%
   \hspace{\rpgicons@beforesep}%
-  \tikz[rpg icons, rpg icons/every attack, rpg icons/every #1, actualtext={#1},
+  \tikz[rpg icons, 
+    rpg icons/.meaning to context,
+    rpg icons/every attack, 
+    rpg icons/every attack/.meaning to context, 
+    rpg icons/every #1,
+    rpg icons/every #1/.meaning to context,
+    actualtext={#1},
     baseline=\rpgicons@baseline, #2] {
+      \ifmemoizing\xtoksapp\mmzContextExtra{baseline=\the\rpgicons@baseline,
+        actualtext=\UseName{l__tikz_tagging_actualtext_tl},
+      }\fi
     \node[\rpgicons@shape@variant{#1}, draw, scale=.333] at (0cm,0cm) {};
     \path[draw=none, scale=.333] ([yshift=-1pt].425cm,.425cm) rectangle ([yshift=1pt]-.425cm,-.425cm);
   }%
@@ -2707,8 +2813,17 @@
 
 \NewDocumentCommand{\rpgiconscondition}{ m O{} }{%
   \hspace{\rpgicons@beforesep}%
-  \tikz[rpg icons, rpg icons/every condition, rpg icons/every #1, actualtext={#1},
+  \tikz[rpg icons, 
+    rpg icons/.meaning to context,
+    rpg icons/every condition, 
+    rpg icons/every condition/.meaning to context, 
+    rpg icons/every #1,
+    rpg icons/every #1/.meaning to context,
+    actualtext={#1},
     baseline=\rpgicons@baseline, #2] {
+      \ifmemoizing\xtoksapp\mmzContextExtra{baseline=\the\rpgicons@baseline,
+        actualtext=\UseName{l__tikz_tagging_actualtext_tl},
+      }\fi
     \node[\rpgicons@shape@variant{#1}, draw, scale=.333] at (0cm,0cm) {};
     \path[draw=none, scale=.333] ([yshift=-1pt].425cm,.425cm) rectangle ([yshift=1pt]-.425cm,-.425cm);
   }%
@@ -3535,9 +3650,25 @@
     \def\rpgicons@classiconbg{bgneg}\else%
     \def\rpgicons@classiconbg{bgpos}\fi%
   \hspace{\rpgicons@beforesep}%
-  \tikz[rpg icons, rpg icons/every class, rpg icons/every #2, actualtext={#2},
+  \tikz[rpg icons, 
+    rpg icons/.meaning to context,
+    rpg icons/every class, 
+    rpg icons/every class/.meaning to context, 
+    rpg icons/every #2,
+    rpg icons/every #2/.meaning to context,
+    actualtext={#2},
     baseline=\rpgicons@baseline, fgpos/.style={draw=rpgicons@bg, line width=.6pt}, fgneg/.style={draw},
     bgpos/.style={fill}, bgneg/.style={draw}, #3] {
+    \ifmemoizing
+      \begingroup
+      \color{rpgicons@bg}%
+      \xtoksapp\mmzContextExtra{%
+        baseline=\the\rpgicons@baseline,
+        draw=\current@color,
+        actualtext=\UseName{l__tikz_tagging_actualtext_tl},
+      }
+      \endgroup
+    \fi
     \path[scale=.333, \rpgicons@classiconbg] (-.45cm,-.45cm) rectangle (.45cm,.45cm);
     \node[\rpgicons@shape@variant{#2}, \rpgicons@classiconfg, scale=.225] at (0cm,0cm) {};
     \path[draw=none, scale=.333] ([yshift=-1pt].425cm,.425cm) rectangle ([yshift=1pt]-.425cm,-.425cm);
@@ -3699,9 +3830,25 @@
     \def\rpgicons@alignmenticonbg{bgneg}\else%
     \def\rpgicons@alignmenticonbg{bgpos}\fi%
   \hspace{\rpgicons@beforesep}%
-  \tikz[rpg icons, rpg icons/every alignment, rpg icons/every #2, actualtext={#2},
+  \tikz[rpg icons, 
+    rpg icons/.meaning to context,
+    rpg icons/every alignment, 
+    rpg icons/every alignment/.meaning to context, 
+    rpg icons/every #2,
+    rpg icons/every #2/.meaning to context,
+    actualtext={#2},
     baseline=\rpgicons@baseline, fgpos/.style={draw=rpgicons@bg, line width=.6pt}, fgneg/.style={draw},
     bgpos/.style={fill}, bgneg/.style={draw}, #3] {
+    \ifmemoizing
+      \begingroup
+      \color{rpgicons@bg}%
+      \xtoksapp\mmzContextExtra{%
+        baseline=\the\rpgicons@baseline,
+        draw=\current@color,
+        actualtext=\UseName{l__tikz_tagging_actualtext_tl},
+      }
+      \endgroup
+    \fi
     \path[scale=.333, \rpgicons@alignmenticonbg] (30:.525cm)
       -- (90:.525cm) -- (150:.525cm) -- (210:.525cm) -- (270:.525cm) -- (330:.525cm) -- cycle;
     \node[\rpgicons@shape@variant{#2}, \rpgicons@alignmenticonfg, scale=.225] at (0cm,0cm) {};
@@ -3895,8 +4042,17 @@
   }{%
     \def\rpgicons@currencyactualtext{#3 #1}%
   }%
-  \tikz[rpg icons, rpg icons/every currency, rpg icons/every #1, actualtext=\rpgicons@currencyactualtext,
+  \tikz[rpg icons,
+    rpg icons/.meaning to context, 
+    rpg icons/every currency,
+    rpg icons/every currency/.meaning to context, 
+    rpg icons/every #1,
+    rpg icons/every #1/.meaning to context,
+    actualtext=\rpgicons@currencyactualtext,
     baseline=\rpgicons@baseline, #2] {
+    \ifmemoizing\xtoksapp\mmzContextExtra{baseline=\the\rpgicons@baseline,
+        actualtext=\UseName{l__tikz_tagging_actualtext_tl},
+    }\fi
     \node[\rpgicons@shape@variant{#1}, draw, scale=.333] at (0cm,0cm) {};
     \path[draw=none, scale=.333] ([yshift=-1pt].425cm,.425cm) rectangle ([yshift=1pt]-.425cm,-.425cm);
   }%
@@ -4064,6 +4220,28 @@
     }
     \AssignTaggingSocketPlug { rpgicons/roll/after } { actualtext }
   }
+
+  \ifrpgicons@mmzx@tag@bool
+    \socket_if_plug_exist:nnF { memoize/include/extern/before }
+      { rpgicons / roll / actualtext } 
+    {
+      \NewTaggingSocketPlug { memoize/include/extern/before } 
+      { rpgicons / roll / actualtext } 
+      {
+        \tag_socket_use:no { rpgicons / roll / before } { \the\mmzxtagtoks }
+      }
+    }
+    \socket_if_plug_exist:nnF { memoize/include/extern/after }
+      { rpgicons / roll / actualtext } 
+    {
+      \NewTaggingSocketPlug { memoize/include/extern/after } 
+      { rpgicons / roll / actualtext } 
+      {
+        \tag_socket_use:no { rpgicons / roll / after }
+      }
+    }
+  \fi
+
 } {
   \msg_warning:nn { rpgicons } { tagging-unsupported }
   \cs_if_exist:NF \tag_socket_use:n {
@@ -4168,7 +4346,43 @@
 \NewDocumentCommand { \rpgiconsroll } { m } {
   \mode_leave_vertical:
   \__rpgicons_roll_prepare_actualtext:Nn \l__rpgicons_roll_actualtext_tl {#1}
+  \ifmemoizing
+    \begingroup
+    \color{rpgicons@bg}
+    \xtoksapp\mmzContextExtra{
+      actualtext=\l__rpgicons_roll_actualtext_tl,
+      bg=\current@color,
+      variant=\rpgicons@variant,
+      % beforesep=\rpgicons@beforesep,
+      % aftersep=\rpgicons@aftersep,
+    }
+    \endgroup
+  \fi
   \tag_socket_use:nV { rpgicons/roll/before } \l__rpgicons_roll_actualtext_tl
+  \ifrpgicons@mmzx@tag@bool
+    \xtoksapp\mmzCCMemo {
+      \exp_not:N \mmzxtagtoks
+      =
+      \c_left_brace_str
+      \l_rpgicons_icon_actualtext_tl
+      \the\mmzxtagtoks
+      \c_right_brace_str
+      \exp_not:N \AssignSocketPlug
+      \c_left_brace_str
+      tagsupport/memoize/include/extern/before
+      \c_right_brace_str
+      \c_left_brace_str
+      rpgicons / roll / actualtext
+      \c_right_brace_str
+      \exp_not:N \AssignSocketPlug
+      \c_left_brace_str
+      tagsupport/memoize/include/extern/after
+      \c_right_brace_str
+      \c_left_brace_str
+      rpgicons / roll / actualtext
+      \c_right_brace_str
+    }
+  \fi
   \tag_suspend:n { \rpgiconsroll }
   \__rpgicons_roll_syntax_parse:e {#1}
   \tag_resume:n { \rpgiconsroll }

--- a/rpgicons-pgf.sty
+++ b/rpgicons-pgf.sty
@@ -31,9 +31,13 @@
   \IfPackageLoadedF{nomemoize}{
     \newif\ifmemoize\memoizefalse
     \newif\ifmemoizing\memoizingfalse
+    \RequirePackage{pgfkeys}
     \pgfqkeys{/handlers}{
       .meaning ~ to ~ context/.code = {},
     }
+    \pgfkeys{/mmz/.cd,
+      context/.code={},
+    }%
   }
 }
 \ExplSyntaxOff


### PR DESCRIPTION
WIP

- rolls are completely untested
- icons are minimally tested

but I'm not even sure if both are needed together or not, so this also probably needs adjustment there.

Needs at least the `memoize-ext` 0.3.3. To avoid multiply-defined labels, it needs what will be 0.3.4.